### PR TITLE
Changes discussed on mailing list plus minor doc error

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/Classfile.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/Classfile.java
@@ -244,7 +244,7 @@ public sealed interface Classfile
 
     /**
      * Build a classfile into a byte array using the provided constant pool
-     * builder (which encapsulates classfile processing options.)
+     * builder.
      *
      * @param thisClassEntry the name of the class to build
      * @param constantPool the constant pool builder
@@ -615,6 +615,21 @@ public sealed interface Classfile
     int TAG_UNICODE = 2;
     int TAG_UTF8 = 1;
 
+    // annotation element values
+    char AEV_BYTE = 'B';
+    char AEV_CHAR = 'C';
+    char AEV_DOUBLE = 'D';
+    char AEV_FLOAT = 'F';
+    char AEV_INT = 'I';
+    char AEV_LONG = 'J';
+    char AEV_SHORT = 'S';
+    char AEV_BOOLEAN = 'Z';
+    char AEV_STRING = 's';
+    char AEV_ENUM = 'e';
+    char AEV_CLASS = 'c';
+    char AEV_ANNOTATION = '@';
+    char AEV_ARRAY = '[';
+
     //type annotations
     int TAT_CLASS_TYPE_PARAMETER = 0x00;
     int TAT_METHOD_TYPE_PARAMETER = 0x01;
@@ -675,8 +690,14 @@ public sealed interface Classfile
     int JAVA_21_VERSION = 65;
     int JAVA_22_VERSION = 66;
 
-    int LATEST_MAJOR_VERSION = JAVA_22_VERSION;
-    int LATEST_MINOR_VERSION = 0;
     int PREVIEW_MINOR_VERSION = -1;
+
+    static int latestMajorVersion() {
+        return JAVA_22_VERSION;
+    }
+
+    static int latestMinorVersion() {
+        return 0;
+    }
 
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AnnotationImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AnnotationImpl.java
@@ -30,6 +30,8 @@ import jdk.internal.classfile.constantpool.*;
 import java.lang.constant.ConstantDesc;
 import java.util.List;
 
+import static jdk.internal.classfile.Classfile.*;
+
 public final class AnnotationImpl implements Annotation {
     private final Utf8Entry className;
     private final List<AnnotationElement> elements;
@@ -113,7 +115,7 @@ public final class AnnotationImpl implements Annotation {
 
         @Override
         public char tag() {
-            return 's';
+            return AEV_STRING;
         }
 
         @Override
@@ -127,7 +129,7 @@ public final class AnnotationImpl implements Annotation {
 
         @Override
         public char tag() {
-            return 'D';
+            return AEV_DOUBLE;
         }
 
         @Override
@@ -141,7 +143,7 @@ public final class AnnotationImpl implements Annotation {
 
         @Override
         public char tag() {
-            return 'F';
+            return AEV_FLOAT;
         }
 
         @Override
@@ -155,7 +157,7 @@ public final class AnnotationImpl implements Annotation {
 
         @Override
         public char tag() {
-            return 'J';
+            return AEV_LONG;
         }
 
         @Override
@@ -169,7 +171,7 @@ public final class AnnotationImpl implements Annotation {
 
         @Override
         public char tag() {
-            return 'I';
+            return AEV_INT;
         }
 
         @Override
@@ -183,7 +185,7 @@ public final class AnnotationImpl implements Annotation {
 
         @Override
         public char tag() {
-            return 'S';
+            return AEV_SHORT;
         }
 
         @Override
@@ -197,7 +199,7 @@ public final class AnnotationImpl implements Annotation {
 
         @Override
         public char tag() {
-            return 'C';
+            return AEV_CHAR;
         }
 
         @Override
@@ -211,7 +213,7 @@ public final class AnnotationImpl implements Annotation {
 
         @Override
         public char tag() {
-            return 'B';
+            return AEV_BYTE;
         }
 
         @Override
@@ -225,7 +227,7 @@ public final class AnnotationImpl implements Annotation {
 
         @Override
         public char tag() {
-            return 'Z';
+            return AEV_BOOLEAN;
         }
 
         @Override
@@ -243,7 +245,7 @@ public final class AnnotationImpl implements Annotation {
 
         @Override
         public char tag() {
-            return '[';
+            return AEV_ARRAY;
         }
 
         @Override
@@ -258,7 +260,7 @@ public final class AnnotationImpl implements Annotation {
             implements AnnotationValue.OfEnum {
         @Override
         public char tag() {
-            return 'e';
+            return AEV_ENUM;
         }
 
         @Override
@@ -274,7 +276,7 @@ public final class AnnotationImpl implements Annotation {
             implements AnnotationValue.OfAnnotation {
         @Override
         public char tag() {
-            return '@';
+            return AEV_ANNOTATION;
         }
 
         @Override
@@ -289,7 +291,7 @@ public final class AnnotationImpl implements Annotation {
             implements AnnotationValue.OfClass {
         @Override
         public char tag() {
-            return 'c';
+            return AEV_CLASS;
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AnnotationReader.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AnnotationReader.java
@@ -58,19 +58,19 @@ class AnnotationReader {
         char tag = (char) classReader.readU1(p);
         ++p;
         return switch (tag) {
-            case 'B' -> new AnnotationImpl.OfByteImpl((IntegerEntry)classReader.readEntry(p));
-            case 'C' -> new AnnotationImpl.OfCharacterImpl((IntegerEntry)classReader.readEntry(p));
-            case 'D' -> new AnnotationImpl.OfDoubleImpl((DoubleEntry)classReader.readEntry(p));
-            case 'F' -> new AnnotationImpl.OfFloatImpl((FloatEntry)classReader.readEntry(p));
-            case 'I' -> new AnnotationImpl.OfIntegerImpl((IntegerEntry)classReader.readEntry(p));
-            case 'J' -> new AnnotationImpl.OfLongImpl((LongEntry)classReader.readEntry(p));
-            case 'S' -> new AnnotationImpl.OfShortImpl((IntegerEntry)classReader.readEntry(p));
-            case 'Z' -> new AnnotationImpl.OfBooleanImpl((IntegerEntry)classReader.readEntry(p));
-            case 's' -> new AnnotationImpl.OfStringImpl(classReader.readUtf8Entry(p));
-            case 'e' -> new AnnotationImpl.OfEnumImpl(classReader.readUtf8Entry(p), classReader.readUtf8Entry(p + 2));
-            case 'c' -> new AnnotationImpl.OfClassImpl(classReader.readUtf8Entry(p));
-            case '@' -> new AnnotationImpl.OfAnnotationImpl(readAnnotation(classReader, p));
-            case '[' -> {
+            case AEV_BYTE -> new AnnotationImpl.OfByteImpl((IntegerEntry)classReader.readEntry(p));
+            case AEV_CHAR -> new AnnotationImpl.OfCharacterImpl((IntegerEntry)classReader.readEntry(p));
+            case AEV_DOUBLE -> new AnnotationImpl.OfDoubleImpl((DoubleEntry)classReader.readEntry(p));
+            case AEV_FLOAT -> new AnnotationImpl.OfFloatImpl((FloatEntry)classReader.readEntry(p));
+            case AEV_INT -> new AnnotationImpl.OfIntegerImpl((IntegerEntry)classReader.readEntry(p));
+            case AEV_LONG -> new AnnotationImpl.OfLongImpl((LongEntry)classReader.readEntry(p));
+            case AEV_SHORT -> new AnnotationImpl.OfShortImpl((IntegerEntry)classReader.readEntry(p));
+            case AEV_BOOLEAN -> new AnnotationImpl.OfBooleanImpl((IntegerEntry)classReader.readEntry(p));
+            case AEV_STRING -> new AnnotationImpl.OfStringImpl(classReader.readUtf8Entry(p));
+            case AEV_ENUM -> new AnnotationImpl.OfEnumImpl(classReader.readUtf8Entry(p), classReader.readUtf8Entry(p + 2));
+            case AEV_CLASS -> new AnnotationImpl.OfClassImpl(classReader.readUtf8Entry(p));
+            case AEV_ANNOTATION -> new AnnotationImpl.OfAnnotationImpl(readAnnotation(classReader, p));
+            case AEV_ARRAY -> {
                 int numValues = classReader.readU2(p);
                 p += 2;
                 var values = new Object[numValues];

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
@@ -68,8 +68,8 @@ public final class DirectClassBuilder
         this.flags = Classfile.DEFAULT_CLASS_FLAGS;
         this.superclassEntry = null;
         this.interfaceEntries = Collections.emptyList();
-        this.majorVersion = Classfile.LATEST_MAJOR_VERSION;
-        this.minorVersion = Classfile.LATEST_MINOR_VERSION;
+        this.majorVersion = Classfile.latestMajorVersion();
+        this.minorVersion = Classfile.latestMinorVersion();
     }
 
     @Override


### PR DESCRIPTION
See https://mail.openjdk.org/pipermail/classfile-api-dev/2023-June/000378.html
1. Added constnats for annotation element value tags
2. Moved the latest major/minor versions into methods to prevent javac using constants.

Also there's one missing doc change out of GitHub review's scope (https://github.com/openjdk/jdk/pull/14180#pullrequestreview-1490021062) included in this patch.