### PR TITLE
Minor BufWriterImpl improvements

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
@@ -25,8 +25,6 @@
 package jdk.internal.classfile.impl;
 
 
-import jdk.internal.util.ArraysSupport;
-
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
-10k bytecode executed on startup

Profiling some of the microbenchmarks shows writeIntBytes is often one of the hottest methods, eg. `AdHocAdapt.transform`:

```
Method                                                                                                  Samples Percent
------------------------------------------------------------------------------------------------------- ------- -------
jdk.internal.classfile.impl.BufWriterImpl.writeIntBytes(int, long)                                           28   6,51%
jdk.internal.classfile.impl.ClassReaderImpl.<init>(byte[], ClassFileImpl)                                    19   4,42%
jdk.internal.classfile.impl.AbstractInstruction$BoundInstruction.<init>(Opcode, int, CodeImpl, int)          18   4,19%
jdk.internal.util.ArraysSupport.vectorizedMismatch(Object, long, Object, long, int, int)                     16   3,72%
jdk.internal.classfile.impl.SplitConstantPool.map()                                                          14   3,26%
```

With this patch it drops off the list and the specialized `writeU2` etc shows up, but only further down the list:
```
Method                                                                                                  Samples Percent
------------------------------------------------------------------------------------------------------- ------- -------
jdk.internal.classfile.impl.CodeImpl.forEachElement(Consumer)                                                24   5,83%
jdk.internal.classfile.impl.ClassReaderImpl.<init>(byte[], ClassFileImpl)                                    22   5,34%
jdk.internal.classfile.impl.AbstractInstruction$BoundInstruction.<init>(Opcode, int, CodeImpl, int)          17   4,13%
jdk.internal.util.ArraysSupport.vectorizedMismatch(Object, long, Object, long, int, int)                     17   4,13%
jdk.internal.classfile.impl.ClassReaderImpl.utf8EntryByIndex(int)                                            13   3,16%
jdk.internal.util.ArraysSupport.unsignedHashCode(int, byte[], int, int)                                      12   2,91%
jdk.internal.classfile.impl.BufWriterImpl.reserveSpace(int)                                                  12   2,91%
jdk.internal.classfile.impl.BufWriterImpl.writeU2(int)                                                       11   2,67%
```
