### PR TITLE
Move implementation classes from java.lang.constant to jdk.internal.constant

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ClassDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDesc.java
@@ -28,12 +28,11 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.TypeDescriptor;
 import java.util.stream.Stream;
 
+import jdk.internal.constant.PrimitiveClassDescImpl;
+import jdk.internal.constant.ReferenceClassDescImpl;
 import sun.invoke.util.Wrapper;
 
-import static java.lang.constant.ConstantUtils.binaryToInternal;
-import static java.lang.constant.ConstantUtils.dropLastChar;
-import static java.lang.constant.ConstantUtils.internalToBinary;
-import static java.lang.constant.ConstantUtils.validateMemberName;
+import static jdk.internal.constant.ConstantUtils.*;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
@@ -77,7 +76,7 @@ public sealed interface ClassDesc
      * @see ClassDesc#ofInternalName(String)
      */
     static ClassDesc of(String name) {
-        ConstantUtils.validateBinaryClassName(requireNonNull(name));
+        validateBinaryClassName(requireNonNull(name));
         return ClassDesc.ofDescriptor("L" + binaryToInternal(name) + ";");
     }
 
@@ -103,7 +102,7 @@ public sealed interface ClassDesc
      * @since 20
      */
     static ClassDesc ofInternalName(String name) {
-        ConstantUtils.validateInternalClassName(requireNonNull(name));
+        validateInternalClassName(requireNonNull(name));
         return ClassDesc.ofDescriptor("L" + name + ";");
     }
 
@@ -122,7 +121,7 @@ public sealed interface ClassDesc
      * not in the correct format
      */
     static ClassDesc of(String packageName, String className) {
-        ConstantUtils.validateBinaryClassName(requireNonNull(packageName));
+        validateBinaryClassName(requireNonNull(packageName));
         if (packageName.isEmpty()) {
             return of(className);
         }
@@ -162,7 +161,7 @@ public sealed interface ClassDesc
         return (descriptor.length() == 1)
                ? Wrapper.forPrimitiveType(descriptor.charAt(0)).classDescriptor()
                // will throw IAE on descriptor.length == 0 or if array dimensions too long
-               : new ReferenceClassDescImpl(descriptor);
+               : ReferenceClassDescImpl.of(descriptor);
     }
 
     /**
@@ -175,11 +174,11 @@ public sealed interface ClassDesc
      * @jvms 4.4.1 The CONSTANT_Class_info Structure
      */
     default ClassDesc arrayType() {
-        int depth = ConstantUtils.arrayDepth(descriptorString());
-        if (depth >= ConstantUtils.MAX_ARRAY_TYPE_DESC_DIMENSIONS) {
+        int depth = arrayDepth(descriptorString());
+        if (depth >= MAX_ARRAY_TYPE_DESC_DIMENSIONS) {
             throw new IllegalStateException(
                     "Cannot create an array type descriptor with more than " +
-                    ConstantUtils.MAX_ARRAY_TYPE_DESC_DIMENSIONS + " dimensions");
+                    MAX_ARRAY_TYPE_DESC_DIMENSIONS + " dimensions");
         }
         return arrayType(1);
     }
@@ -201,17 +200,17 @@ public sealed interface ClassDesc
             throw new IllegalArgumentException("rank " + rank + " is not a positive value");
         }
         try {
-            int currentDepth = ConstantUtils.arrayDepth(descriptorString());
+            int currentDepth = arrayDepth(descriptorString());
             netRank = Math.addExact(currentDepth, rank);
-            if (netRank > ConstantUtils.MAX_ARRAY_TYPE_DESC_DIMENSIONS) {
+            if (netRank > MAX_ARRAY_TYPE_DESC_DIMENSIONS) {
                 throw new IllegalArgumentException("rank: " + netRank +
                                                    " exceeds maximum supported dimension of " +
-                                                   ConstantUtils.MAX_ARRAY_TYPE_DESC_DIMENSIONS);
+                                                   MAX_ARRAY_TYPE_DESC_DIMENSIONS);
             }
         } catch (ArithmeticException ae) {
             throw new IllegalArgumentException("Integer overflow in rank computation");
         }
-        return ClassDesc.ofDescriptor("[".repeat(rank) + descriptorString());
+        return ReferenceClassDescImpl.ofTrusted("[".repeat(rank) + descriptorString());
     }
 
     /**
@@ -235,7 +234,7 @@ public sealed interface ClassDesc
         validateMemberName(nestedName, false);
         if (!isClassOrInterface())
             throw new IllegalStateException("Outer class is not a class or interface type");
-        return ClassDesc.ofDescriptor(dropLastChar(descriptorString()) + "$" + nestedName + ";");
+        return ReferenceClassDescImpl.ofTrusted(dropLastChar(descriptorString()) + "$" + nestedName + ";");
     }
 
     /**
@@ -299,7 +298,15 @@ public sealed interface ClassDesc
      * if this descriptor does not describe an array type
      */
     default ClassDesc componentType() {
-        return isArray() ? ClassDesc.ofDescriptor(descriptorString().substring(1)) : null;
+        if (isArray()) {
+            String desc = descriptorString();
+            if (desc.length() == 2) {
+                return Wrapper.forBasicType(desc.charAt(1)).classDescriptor();
+            } else {
+                return ReferenceClassDescImpl.ofTrusted(desc.substring(1));
+            }
+        }
+        return null;
     }
 
     /**
@@ -312,7 +319,7 @@ public sealed interface ClassDesc
     default String packageName() {
         if (!isClassOrInterface())
             return "";
-        String className = internalToBinary(ConstantUtils.dropFirstAndLastChar(descriptorString()));
+        String className = internalToBinary(dropFirstAndLastChar(descriptorString()));
         int index = className.lastIndexOf('.');
         return (index == -1) ? "" : className.substring(0, index);
     }
@@ -336,7 +343,7 @@ public sealed interface ClassDesc
                                                 descriptorString().length() - 1);
         }
         else if (isArray()) {
-            int depth = ConstantUtils.arrayDepth(descriptorString());
+            int depth = arrayDepth(descriptorString());
             ClassDesc c = this;
             for (int i=0; i<depth; i++)
                 c = c.componentType();

--- a/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
@@ -24,6 +24,9 @@
  */
 package java.lang.constant;
 
+import jdk.internal.constant.PrimitiveClassDescImpl;
+import jdk.internal.constant.ReferenceClassDescImpl;
+
 import java.lang.Enum.EnumDesc;
 import java.lang.invoke.CallSite;
 import java.lang.invoke.ConstantBootstraps;
@@ -64,115 +67,115 @@ public final class ConstantDescs {
     // Don't change the order of these declarations!
 
     /** {@link ClassDesc} representing {@link Object} */
-    public static final ClassDesc CD_Object = new ReferenceClassDescImpl("Ljava/lang/Object;");
+    public static final ClassDesc CD_Object = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Object;");
 
     /** {@link ClassDesc} representing {@link String} */
-    public static final ClassDesc CD_String = new ReferenceClassDescImpl("Ljava/lang/String;");
+    public static final ClassDesc CD_String = ReferenceClassDescImpl.ofTrusted("Ljava/lang/String;");
 
     /** {@link ClassDesc} representing {@link Class} */
-    public static final ClassDesc CD_Class = new ReferenceClassDescImpl("Ljava/lang/Class;");
+    public static final ClassDesc CD_Class = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Class;");
 
     /** {@link ClassDesc} representing {@link Number} */
-    public static final ClassDesc CD_Number = new ReferenceClassDescImpl("Ljava/lang/Number;");
+    public static final ClassDesc CD_Number = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Number;");
 
     /** {@link ClassDesc} representing {@link Integer} */
-    public static final ClassDesc CD_Integer = new ReferenceClassDescImpl("Ljava/lang/Integer;");
+    public static final ClassDesc CD_Integer = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Integer;");
 
     /** {@link ClassDesc} representing {@link Long} */
-    public static final ClassDesc CD_Long = new ReferenceClassDescImpl("Ljava/lang/Long;");
+    public static final ClassDesc CD_Long = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Long;");
 
     /** {@link ClassDesc} representing {@link Float} */
-    public static final ClassDesc CD_Float = new ReferenceClassDescImpl("Ljava/lang/Float;");
+    public static final ClassDesc CD_Float = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Float;");
 
     /** {@link ClassDesc} representing {@link Double} */
-    public static final ClassDesc CD_Double = new ReferenceClassDescImpl("Ljava/lang/Double;");
+    public static final ClassDesc CD_Double = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Double;");
 
     /** {@link ClassDesc} representing {@link Short} */
-    public static final ClassDesc CD_Short = new ReferenceClassDescImpl("Ljava/lang/Short;");
+    public static final ClassDesc CD_Short = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Short;");
 
     /** {@link ClassDesc} representing {@link Byte} */
-    public static final ClassDesc CD_Byte = new ReferenceClassDescImpl("Ljava/lang/Byte;");
+    public static final ClassDesc CD_Byte = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Byte;");
 
     /** {@link ClassDesc} representing {@link Character} */
-    public static final ClassDesc CD_Character = new ReferenceClassDescImpl("Ljava/lang/Character;");
+    public static final ClassDesc CD_Character = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Character;");
 
     /** {@link ClassDesc} representing {@link Boolean} */
-    public static final ClassDesc CD_Boolean = new ReferenceClassDescImpl("Ljava/lang/Boolean;");
+    public static final ClassDesc CD_Boolean = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Boolean;");
 
     /** {@link ClassDesc} representing {@link Void} */
-    public static final ClassDesc CD_Void = new ReferenceClassDescImpl("Ljava/lang/Void;");
+    public static final ClassDesc CD_Void = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Void;");
 
     /** {@link ClassDesc} representing {@link Throwable} */
-    public static final ClassDesc CD_Throwable = new ReferenceClassDescImpl("Ljava/lang/Throwable;");
+    public static final ClassDesc CD_Throwable = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Throwable;");
 
     /** {@link ClassDesc} representing {@link Exception} */
-    public static final ClassDesc CD_Exception = new ReferenceClassDescImpl("Ljava/lang/Exception;");
+    public static final ClassDesc CD_Exception = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Exception;");
 
     /** {@link ClassDesc} representing {@link Enum} */
-    public static final ClassDesc CD_Enum = new ReferenceClassDescImpl("Ljava/lang/Enum;");
+    public static final ClassDesc CD_Enum = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Enum;");
 
     /** {@link ClassDesc} representing {@link VarHandle} */
-    public static final ClassDesc CD_VarHandle = new ReferenceClassDescImpl("Ljava/lang/invoke/VarHandle;");
+    public static final ClassDesc CD_VarHandle = ReferenceClassDescImpl.ofTrusted("Ljava/lang/invoke/VarHandle;");
 
     /** {@link ClassDesc} representing {@link MethodHandles} */
-    public static final ClassDesc CD_MethodHandles = new ReferenceClassDescImpl("Ljava/lang/invoke/MethodHandles;");
+    public static final ClassDesc CD_MethodHandles = ReferenceClassDescImpl.ofTrusted("Ljava/lang/invoke/MethodHandles;");
 
     /** {@link ClassDesc} representing {@link MethodHandles.Lookup} */
-    public static final ClassDesc CD_MethodHandles_Lookup = new ReferenceClassDescImpl("Ljava/lang/invoke/MethodHandles$Lookup;");
+    public static final ClassDesc CD_MethodHandles_Lookup = ReferenceClassDescImpl.ofTrusted("Ljava/lang/invoke/MethodHandles$Lookup;");
 
     /** {@link ClassDesc} representing {@link MethodHandle} */
-    public static final ClassDesc CD_MethodHandle = new ReferenceClassDescImpl("Ljava/lang/invoke/MethodHandle;");
+    public static final ClassDesc CD_MethodHandle = ReferenceClassDescImpl.ofTrusted("Ljava/lang/invoke/MethodHandle;");
 
     /** {@link ClassDesc} representing {@link MethodType} */
-    public static final ClassDesc CD_MethodType = new ReferenceClassDescImpl("Ljava/lang/invoke/MethodType;");
+    public static final ClassDesc CD_MethodType = ReferenceClassDescImpl.ofTrusted("Ljava/lang/invoke/MethodType;");
 
     /** {@link ClassDesc} representing {@link CallSite} */
-    public static final ClassDesc CD_CallSite = new ReferenceClassDescImpl("Ljava/lang/invoke/CallSite;");
+    public static final ClassDesc CD_CallSite = ReferenceClassDescImpl.ofTrusted("Ljava/lang/invoke/CallSite;");
 
     /** {@link ClassDesc} representing {@link Collection} */
-    public static final ClassDesc CD_Collection = new ReferenceClassDescImpl("Ljava/util/Collection;");
+    public static final ClassDesc CD_Collection = ReferenceClassDescImpl.ofTrusted("Ljava/util/Collection;");
 
     /** {@link ClassDesc} representing {@link List} */
-    public static final ClassDesc CD_List = new ReferenceClassDescImpl("Ljava/util/List;");
+    public static final ClassDesc CD_List = ReferenceClassDescImpl.ofTrusted("Ljava/util/List;");
 
     /** {@link ClassDesc} representing {@link Set} */
-    public static final ClassDesc CD_Set = new ReferenceClassDescImpl("Ljava/util/Set;");
+    public static final ClassDesc CD_Set = ReferenceClassDescImpl.ofTrusted("Ljava/util/Set;");
 
     /** {@link ClassDesc} representing {@link Map} */
-    public static final ClassDesc CD_Map = new ReferenceClassDescImpl("Ljava/util/Map;");
+    public static final ClassDesc CD_Map = ReferenceClassDescImpl.ofTrusted("Ljava/util/Map;");
 
     /** {@link ClassDesc} representing {@link ConstantDesc} */
-    public static final ClassDesc CD_ConstantDesc = new ReferenceClassDescImpl("Ljava/lang/constant/ConstantDesc;");
+    public static final ClassDesc CD_ConstantDesc = ReferenceClassDescImpl.ofTrusted("Ljava/lang/constant/ConstantDesc;");
 
     /** {@link ClassDesc} representing {@link ClassDesc} */
-    public static final ClassDesc CD_ClassDesc = new ReferenceClassDescImpl("Ljava/lang/constant/ClassDesc;");
+    public static final ClassDesc CD_ClassDesc = ReferenceClassDescImpl.ofTrusted("Ljava/lang/constant/ClassDesc;");
 
     /** {@link ClassDesc} representing {@link EnumDesc} */
-    public static final ClassDesc CD_EnumDesc = new ReferenceClassDescImpl("Ljava/lang/Enum$EnumDesc;");
+    public static final ClassDesc CD_EnumDesc = ReferenceClassDescImpl.ofTrusted("Ljava/lang/Enum$EnumDesc;");
 
     /** {@link ClassDesc} representing {@link MethodTypeDesc} */
-    public static final ClassDesc CD_MethodTypeDesc = new ReferenceClassDescImpl("Ljava/lang/constant/MethodTypeDesc;");
+    public static final ClassDesc CD_MethodTypeDesc = ReferenceClassDescImpl.ofTrusted("Ljava/lang/constant/MethodTypeDesc;");
 
     /** {@link ClassDesc} representing {@link MethodHandleDesc} */
-    public static final ClassDesc CD_MethodHandleDesc = new ReferenceClassDescImpl("Ljava/lang/constant/MethodHandleDesc;");
+    public static final ClassDesc CD_MethodHandleDesc = ReferenceClassDescImpl.ofTrusted("Ljava/lang/constant/MethodHandleDesc;");
 
     /** {@link ClassDesc} representing {@link DirectMethodHandleDesc} */
-    public static final ClassDesc CD_DirectMethodHandleDesc = new ReferenceClassDescImpl("Ljava/lang/constant/DirectMethodHandleDesc;");
+    public static final ClassDesc CD_DirectMethodHandleDesc = ReferenceClassDescImpl.ofTrusted("Ljava/lang/constant/DirectMethodHandleDesc;");
 
     /** {@link ClassDesc} representing {@link VarHandleDesc} */
-    public static final ClassDesc CD_VarHandleDesc = new ReferenceClassDescImpl("Ljava/lang/invoke/VarHandle$VarHandleDesc;");
+    public static final ClassDesc CD_VarHandleDesc = ReferenceClassDescImpl.ofTrusted("Ljava/lang/invoke/VarHandle$VarHandleDesc;");
 
     /** {@link ClassDesc} representing {@link DirectMethodHandleDesc.Kind} */
-    public static final ClassDesc CD_MethodHandleDesc_Kind = new ReferenceClassDescImpl("Ljava/lang/constant/DirectMethodHandleDesc$Kind;");
+    public static final ClassDesc CD_MethodHandleDesc_Kind = ReferenceClassDescImpl.ofTrusted("Ljava/lang/constant/DirectMethodHandleDesc$Kind;");
 
     /** {@link ClassDesc} representing {@link DynamicConstantDesc} */
-    public static final ClassDesc CD_DynamicConstantDesc = new ReferenceClassDescImpl("Ljava/lang/constant/DynamicConstantDesc;");
+    public static final ClassDesc CD_DynamicConstantDesc = ReferenceClassDescImpl.ofTrusted("Ljava/lang/constant/DynamicConstantDesc;");
 
     /** {@link ClassDesc} representing {@link DynamicCallSiteDesc} */
-    public static final ClassDesc CD_DynamicCallSiteDesc = new ReferenceClassDescImpl("Ljava/lang/constant/DynamicCallSiteDesc;");
+    public static final ClassDesc CD_DynamicCallSiteDesc = ReferenceClassDescImpl.ofTrusted("Ljava/lang/constant/DynamicCallSiteDesc;");
 
     /** {@link ClassDesc} representing {@link ConstantBootstraps} */
-    public static final ClassDesc CD_ConstantBootstraps = new ReferenceClassDescImpl("Ljava/lang/invoke/ConstantBootstraps;");
+    public static final ClassDesc CD_ConstantBootstraps = ReferenceClassDescImpl.ofTrusted("Ljava/lang/invoke/ConstantBootstraps;");
 
     private static final ClassDesc[] INDY_BOOTSTRAP_ARGS = {
             CD_MethodHandles_Lookup,

--- a/src/java.base/share/classes/java/lang/constant/DirectMethodHandleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/DirectMethodHandleDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,8 @@ package java.lang.constant;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandleInfo;
-import java.util.OptionalInt;
-import java.util.stream.Stream;
 
+import jdk.internal.constant.DirectMethodHandleDescImpl;
 import jdk.internal.vm.annotation.Stable;
 
 import static java.lang.invoke.MethodHandleInfo.REF_getField;
@@ -89,7 +88,7 @@ public sealed interface DirectMethodHandleDesc
          */
         public final boolean isInterface;
         Kind(int refKind) {
-            this(refKind, false);
+            this.refKind = refKind; this.isInterface = false;
         }
 
         Kind(int refKind, boolean isInterface) { this.refKind = refKind; this.isInterface = isInterface; }
@@ -177,23 +176,6 @@ public sealed interface DirectMethodHandleDesc
                         TABLE[i] = kind;
                     }
                 }
-            }
-        }
-
-        /**
-         * Does this {@code Kind} correspond to a virtual method invocation?
-         *
-         * @return if this {@code Kind} corresponds to a virtual method invocation
-         */
-        boolean isVirtualMethod() {
-            switch (this) {
-                case VIRTUAL:
-                case SPECIAL:
-                case INTERFACE_VIRTUAL:
-                case INTERFACE_SPECIAL:
-                    return true;
-                default:
-                    return false;
             }
         }
     }

--- a/src/java.base/share/classes/java/lang/constant/DynamicCallSiteDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/DynamicCallSiteDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,10 +32,10 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import static java.lang.constant.ConstantDescs.CD_String;
-import static java.lang.constant.ConstantUtils.EMPTY_CONSTANTDESC;
-import static java.lang.constant.ConstantUtils.validateMemberName;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
+import static jdk.internal.constant.ConstantUtils.EMPTY_CONSTANTDESC;
+import static jdk.internal.constant.ConstantUtils.validateMemberName;
 
 /**
  * A <a href="package-summary.html#nominal">nominal descriptor</a> for an

--- a/src/java.base/share/classes/java/lang/constant/DynamicConstantDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/DynamicConstantDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,10 +39,10 @@ import java.util.stream.Stream;
 import static java.lang.constant.ConstantDescs.CD_Class;
 import static java.lang.constant.ConstantDescs.CD_VarHandle;
 import static java.lang.constant.ConstantDescs.DEFAULT_NAME;
-import static java.lang.constant.ConstantUtils.EMPTY_CONSTANTDESC;
-import static java.lang.constant.ConstantUtils.validateMemberName;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
+import static jdk.internal.constant.ConstantUtils.EMPTY_CONSTANTDESC;
+import static jdk.internal.constant.ConstantUtils.validateMemberName;
 
 /**
  * A <a href="package-summary.html#nominal">nominal descriptor</a> for a

--- a/src/java.base/share/classes/java/lang/constant/MethodHandleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/MethodHandleDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ package java.lang.constant;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+
+import jdk.internal.constant.DirectMethodHandleDescImpl;
 
 import static java.lang.constant.ConstantDescs.CD_void;
 import static java.lang.constant.DirectMethodHandleDesc.Kind.CONSTRUCTOR;

--- a/src/java.base/share/classes/java/lang/constant/MethodTypeDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/MethodTypeDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,9 @@ import java.lang.invoke.TypeDescriptor;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import jdk.internal.constant.ConstantUtils;
+import jdk.internal.constant.MethodTypeDescImpl;
 
 /**
  * A <a href="package-summary.html#nominal">nominal descriptor</a> for a

--- a/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
@@ -24,6 +24,9 @@
  */
 package java.lang.constant;
 
+import jdk.internal.constant.ConstantUtils;
+import jdk.internal.constant.ModuleDescImpl;
+
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/src/java.base/share/classes/java/lang/constant/PackageDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,9 @@
  * questions.
  */
 package java.lang.constant;
+
+import jdk.internal.constant.ConstantUtils;
+import jdk.internal.constant.PackageDescImpl;
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -25,9 +25,11 @@
 
 package java.lang.invoke;
 
+import jdk.internal.constant.ReferenceClassDescImpl;
 import jdk.internal.misc.CDS;
 import jdk.internal.util.ClassFileDumper;
 import sun.invoke.util.VerifyAccess;
+import sun.invoke.util.Wrapper;
 import sun.security.action.GetBooleanAction;
 
 import java.io.Serializable;
@@ -565,7 +567,20 @@ import static java.lang.invoke.MethodType.methodType;
     }
 
     static ClassDesc classDesc(Class<?> cls) {
-        return ClassDesc.ofDescriptor(cls.descriptorString());
+        if (cls == MethodHandle.class) {
+            return CD_MethodHandle;
+        } else if (cls == MethodType.class) {
+            return CD_MethodType;
+        } else if (cls == Object.class) {
+            return CD_Object;
+        }
+        if (cls.isHidden()) {
+            throw new IllegalArgumentException("Can't describe hidden classes");
+        }
+        String descriptor = cls.descriptorString();
+        return (descriptor.length() == 1)
+                ? Wrapper.forPrimitiveType(descriptor.charAt(0)).classDescriptor()
+                : ReferenceClassDescImpl.ofTrusted(descriptor);
     }
 
     static MethodTypeDesc methodDesc(MethodType mt) {

--- a/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
+++ b/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
@@ -22,10 +22,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package java.lang.constant;
+package jdk.internal.constant;
 
 import sun.invoke.util.Wrapper;
 
+import java.lang.constant.ClassDesc;
+import java.lang.constant.Constable;
+import java.lang.constant.ConstantDesc;
+import java.lang.constant.ConstantDescs;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -35,12 +39,12 @@ import static java.util.Objects.requireNonNull;
 /**
  * Helper methods for the implementation of {@code java.lang.constant}.
  */
-class ConstantUtils {
+public final class ConstantUtils {
     /** an empty constant descriptor */
     public static final ConstantDesc[] EMPTY_CONSTANTDESC = new ConstantDesc[0];
-    static final ClassDesc[] EMPTY_CLASSDESC = new ClassDesc[0];
-    static final Constable[] EMPTY_CONSTABLE = new Constable[0];
-    static final int MAX_ARRAY_TYPE_DESC_DIMENSIONS = 255;
+    public static final ClassDesc[] EMPTY_CLASSDESC = new ClassDesc[0];
+    public static final Constable[] EMPTY_CONSTABLE = new Constable[0];
+    public static final int MAX_ARRAY_TYPE_DESC_DIMENSIONS = 255;
 
     private static final Set<String> pointyNames = Set.of(ConstantDescs.INIT_NAME, ConstantDescs.CLASS_INIT_NAME);
 
@@ -52,8 +56,8 @@ class ConstantUtils {
      * @return the class name passed if valid
      * @throws IllegalArgumentException if the class name is invalid
      */
-    static String validateBinaryClassName(String name) {
-        for (int i=0; i<name.length(); i++) {
+    public static String validateBinaryClassName(String name) {
+        for (int i = 0; i < name.length(); i++) {
             char ch = name.charAt(i);
             if (ch == ';' || ch == '[' || ch == '/')
                 throw new IllegalArgumentException("Invalid class name: " + name);
@@ -62,21 +66,21 @@ class ConstantUtils {
     }
 
     /**
-      * Validates the correctness of an internal class name.
-      * In particular checks for the presence of invalid characters in the name.
-      *
-      * @param name the class name
-      * @return the class name passed if valid
-      * @throws IllegalArgumentException if the class name is invalid
-      */
-     static String validateInternalClassName(String name) {
-         for (int i=0; i<name.length(); i++) {
-             char ch = name.charAt(i);
-             if (ch == ';' || ch == '[' || ch == '.')
-                 throw new IllegalArgumentException("Invalid class name: " + name);
-         }
-         return name;
-     }
+     * Validates the correctness of an internal class name.
+     * In particular checks for the presence of invalid characters in the name.
+     *
+     * @param name the class name
+     * @return the class name passed if valid
+     * @throws IllegalArgumentException if the class name is invalid
+     */
+    public static String validateInternalClassName(String name) {
+        for (int i = 0; i < name.length(); i++) {
+            char ch = name.charAt(i);
+            if (ch == ';' || ch == '[' || ch == '.')
+                throw new IllegalArgumentException("Invalid class name: " + name);
+        }
+        return name;
+    }
 
     /**
      * Validates the correctness of a binary package name.
@@ -160,31 +164,31 @@ class ConstantUtils {
         return name;
     }
 
-    static void validateClassOrInterface(ClassDesc classDesc) {
+    public static void validateClassOrInterface(ClassDesc classDesc) {
         if (!classDesc.isClassOrInterface())
             throw new IllegalArgumentException("not a class or interface type: " + classDesc);
     }
 
-    static int arrayDepth(String descriptorString) {
+    public static int arrayDepth(String descriptorString) {
         int depth = 0;
         while (descriptorString.charAt(depth) == '[')
             depth++;
         return depth;
     }
 
-    static String binaryToInternal(String name) {
+    public static String binaryToInternal(String name) {
         return name.replace('.', '/');
     }
 
-    static String internalToBinary(String name) {
+    public static String internalToBinary(String name) {
         return name.replace('/', '.');
     }
 
-    static String dropLastChar(String s) {
+    public static String dropLastChar(String s) {
         return s.substring(0, s.length() - 1);
     }
 
-    static String dropFirstAndLastChar(String s) {
+    public static String dropFirstAndLastChar(String s) {
         return s.substring(1, s.length() - 1);
     }
 
@@ -196,7 +200,7 @@ class ConstantUtils {
      * @return the list of types
      * @throws IllegalArgumentException if the descriptor string is not valid
      */
-    static List<ClassDesc> parseMethodDescriptor(String descriptor) {
+    public static List<ClassDesc> parseMethodDescriptor(String descriptor) {
         int cur = 0, end = descriptor.length();
         ArrayList<ClassDesc> ptypes = new ArrayList<>();
         ptypes.add(null); // placeholder for return type
@@ -227,7 +231,8 @@ class ConstantUtils {
         if (len == 1) {
             return Wrapper.forPrimitiveType(descriptor.charAt(start)).classDescriptor();
         }
-        return ClassDesc.ofDescriptor(descriptor.substring(start, start + len));
+        // Pre-verified in parseMethodDescriptor; avoid redundant verification
+        return ReferenceClassDescImpl.ofTrusted(descriptor.substring(start, start + len));
     }
 
     private static final char JVM_SIGNATURE_ARRAY = '[';

--- a/src/java.base/share/classes/jdk/internal/constant/MethodTypeDescImpl.java
+++ b/src/java.base/share/classes/jdk/internal/constant/MethodTypeDescImpl.java
@@ -22,10 +22,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package java.lang.constant;
+package jdk.internal.constant;
 
 import jdk.internal.vm.annotation.Stable;
 
+import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.security.AccessController;
@@ -41,7 +43,7 @@ import static java.util.Objects.requireNonNull;
  * {@link MethodType}.  A {@linkplain MethodTypeDescImpl} corresponds to a
  * {@code Constant_MethodType_info} entry in the constant pool of a classfile.
  */
-final class MethodTypeDescImpl implements MethodTypeDesc {
+public final class MethodTypeDescImpl implements MethodTypeDesc {
     private final ClassDesc returnType;
     private final @Stable ClassDesc[] argTypes;
     private @Stable String cachedDescriptorString;
@@ -65,7 +67,7 @@ final class MethodTypeDescImpl implements MethodTypeDesc {
      * @param returnType a {@link ClassDesc} describing the return type
      * @param trustedArgTypes {@link ClassDesc}s describing the trusted parameter types
      */
-    static MethodTypeDescImpl ofTrusted(ClassDesc returnType, ClassDesc[] trustedArgTypes) {
+    public static MethodTypeDescImpl ofTrusted(ClassDesc returnType, ClassDesc[] trustedArgTypes) {
         requireNonNull(returnType);
         if (trustedArgTypes.length == 0) // implicit null check
             return new MethodTypeDescImpl(returnType, ConstantUtils.EMPTY_CLASSDESC);
@@ -86,7 +88,7 @@ final class MethodTypeDescImpl implements MethodTypeDesc {
      * method descriptor
      * @jvms 4.3.3 Method Descriptors
      */
-    static MethodTypeDescImpl ofDescriptor(String descriptor) {
+    public static MethodTypeDescImpl ofDescriptor(String descriptor) {
         // Implicit null-check of descriptor
         List<ClassDesc> ptypes = ConstantUtils.parseMethodDescriptor(descriptor);
         int args = ptypes.size() - 1;

--- a/src/java.base/share/classes/jdk/internal/constant/ModuleDescImpl.java
+++ b/src/java.base/share/classes/jdk/internal/constant/ModuleDescImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,16 +22,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package java.lang.constant;
+package jdk.internal.constant;
+
+import java.lang.constant.ModuleDesc;
 
 /*
- * Implementation of {@code PackageDesc}
- * @param internalName must have been validated
+ * Implementation of {@code ModuleDesc}
+ * @param name must have been validated
  */
-record PackageDescImpl(String internalName) implements PackageDesc {
+public record ModuleDescImpl(String name) implements ModuleDesc {
 
     @Override
     public String toString() {
-        return String.format("PackageDesc[%s]", name());
+        return String.format("ModuleDesc[%s]", name());
     }
 }

--- a/src/java.base/share/classes/jdk/internal/constant/PackageDescImpl.java
+++ b/src/java.base/share/classes/jdk/internal/constant/PackageDescImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,16 +22,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package java.lang.constant;
+package jdk.internal.constant;
+
+import java.lang.constant.PackageDesc;
 
 /*
- * Implementation of {@code ModuleDesc}
- * @param name must have been validated
+ * Implementation of {@code PackageDesc}
+ * @param internalName must have been validated
  */
-record ModuleDescImpl(String name) implements ModuleDesc {
+public record PackageDescImpl(String internalName) implements PackageDesc {
 
     @Override
     public String toString() {
-        return String.format("ModuleDesc[%s]", name());
+        return String.format("PackageDesc[%s]", name());
     }
 }

--- a/src/java.base/share/classes/jdk/internal/constant/PrimitiveClassDescImpl.java
+++ b/src/java.base/share/classes/jdk/internal/constant/PrimitiveClassDescImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package java.lang.constant;
+package jdk.internal.constant;
 
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.DynamicConstantDesc;
 import java.lang.invoke.MethodHandles;
 
 import sun.invoke.util.Wrapper;
@@ -34,7 +37,7 @@ import static java.util.Objects.requireNonNull;
  * A <a href="package-summary.html#nominal">nominal descriptor</a> for the class
  * constant corresponding to a primitive type (e.g., {@code int.class}).
  */
-final class PrimitiveClassDescImpl
+public final class PrimitiveClassDescImpl
         extends DynamicConstantDesc<Class<?>> implements ClassDesc {
 
     private final String descriptor;
@@ -49,7 +52,7 @@ final class PrimitiveClassDescImpl
      * describe a valid primitive type
      * @jvms 4.3 Descriptors
      */
-    PrimitiveClassDescImpl(String descriptor) {
+    public PrimitiveClassDescImpl(String descriptor) {
         super(ConstantDescs.BSM_PRIMITIVE_CLASS, requireNonNull(descriptor), ConstantDescs.CD_Class);
         if (descriptor.length() != 1
             || "VIJCSBFDZ".indexOf(descriptor.charAt(0)) < 0)

--- a/src/java.base/share/classes/jdk/internal/constant/ReferenceClassDescImpl.java
+++ b/src/java.base/share/classes/jdk/internal/constant/ReferenceClassDescImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,20 +22,24 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package java.lang.constant;
+package jdk.internal.constant;
 
+import java.lang.constant.ClassDesc;
 import java.lang.invoke.MethodHandles;
 
-import static java.lang.constant.ConstantUtils.*;
-import static java.util.Objects.requireNonNull;
+import static jdk.internal.constant.ConstantUtils.*;
 
 /**
  * A <a href="package-summary.html#nominal">nominal descriptor</a> for a class,
  * interface, or array type.  A {@linkplain ReferenceClassDescImpl} corresponds to a
  * {@code Constant_Class_info} entry in the constant pool of a classfile.
  */
-final class ReferenceClassDescImpl implements ClassDesc {
+public final class ReferenceClassDescImpl implements ClassDesc {
     private final String descriptor;
+
+    private ReferenceClassDescImpl(String descriptor) {
+        this.descriptor = descriptor;
+    }
 
     /**
      * Creates a {@linkplain ClassDesc} from a descriptor string for a class or
@@ -46,12 +50,23 @@ final class ReferenceClassDescImpl implements ClassDesc {
      * field descriptor string, or does not describe a class or interface type
      * @jvms 4.3.2 Field Descriptors
      */
-    ReferenceClassDescImpl(String descriptor) {
+    public static ReferenceClassDescImpl of(String descriptor) {
         int dLen = descriptor.length();
         int len = ConstantUtils.skipOverFieldSignature(descriptor, 0, dLen, false);
         if (len <= 1 || len != dLen)
             throw new IllegalArgumentException(String.format("not a valid reference type descriptor: %s", descriptor));
-        this.descriptor = descriptor;
+        return new ReferenceClassDescImpl(descriptor);
+    }
+
+    /**
+     * Creates a {@linkplain ClassDesc} from a pre-validated descriptor string
+     * for a class or interface type or an array type.
+     *
+     * @param descriptor a field descriptor string for a class or interface type
+     * @jvms 4.3.2 Field Descriptors
+     */
+    public static ReferenceClassDescImpl ofTrusted(String descriptor) {
+        return new ReferenceClassDescImpl(descriptor);
     }
 
     @Override

--- a/test/jdk/java/lang/constant/boottest/java.base/jdk/internal/constant/ConstantUtilsTest.java
+++ b/test/jdk/java/lang/constant/boottest/java.base/jdk/internal/constant/ConstantUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,9 +21,8 @@
  * questions.
  */
 
-package java.lang.constant;
+package jdk.internal.constant;
 
-import java.lang.invoke.*;
 import java.lang.constant.*;
 import java.util.*;
 
@@ -35,6 +34,7 @@ import static org.testng.Assert.*;
  * @test
  * @bug 8303930
  * @compile ConstantUtilsTest.java
+ * @modules java.base/jdk.internal.constant
  * @run testng ConstantUtilsTest
  * @summary unit tests for methods of java.lang.constant.ConstantUtils that are not covered by other unit tests
  */


### PR DESCRIPTION
Move implementation classes from java.lang.constant to jdk.internal.constant, enabling a few improvements such as using a trusted factory methods from java.lang.invoke and java.lang.classfile. Intended as a follow-up to JDK-8294960-invoke. 

Bootstrap improves from around ~693k bytecode executed to ~670k on HelloLambda. A few targetted microbenchmarks see improvements, in particular `MethodTypeDescFactories.ofDescriptor`:

```
Name                                                             (descString) Cnt     Base     Error      Test    Error  Unit  Change
MethodTypeDescFactories.ofDescriptor  (Ljava/lang/Object;Ljava/lang/String;)I   6  138,040 ±   0,728   135,811 ±  6,182 ns/op   1,02x (p = 0,056 )
MethodTypeDescFactories.ofDescriptor                                      ()V   6   12,422 ±   5,208    11,371 ±  0,202 ns/op   1,09x (p = 0,224 )
MethodTypeDescFactories.ofDescriptor ([IJLjava/lang/String;Z)Ljava/util/List;   6  200,177 ±   4,324   177,817 ± 25,360 ns/op   1,13x (p = 0,002*)
MethodTypeDescFactories.ofDescriptor                    ()[Ljava/lang/String;   6   60,531 ±   3,007    28,605 ±  8,503 ns/op   2,12x (p = 0,000*)
MethodTypeDescFactories.ofDescriptor                                 (..IIJ)V   6  279,014 ±  10,316   202,877 ±  4,435 ns/op   1,38x (p = 0,000*)
MethodTypeDescFactories.ofDescriptor                 (.....................).   6 2224,271 ± 121,582  1312,268 ± 61,346 ns/op   1,69x (p = 0,000*)
  * = significant
```